### PR TITLE
16 char mandate "hashes" using Hashids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.0",
         "ext-mbstring": "*",
+        "ext-bcmath": "*",
         "byrokrat/amount": "^1.0",
         "byrokrat/autogiro": "dev-master",
         "byrokrat/banking": "^1.4",
@@ -34,7 +35,8 @@
         "symfony/expression-language": "^3.3",
         "symfony/console": "^3.3",
         "symfony/event-dispatcher": "^3.3",
-        "symfony/finder": "^3.3"
+        "symfony/finder": "^3.3",
+        "hashids/hashids": "^2"
     },
     "require-dev": {
         "phpspec/phpspec": "^3.4",

--- a/spec/Builder/MandateKeyBuilderSpec.php
+++ b/spec/Builder/MandateKeyBuilderSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace spec\byrokrat\giroapp\Builder;
+
+use byrokrat\giroapp\Builder\MandateKeyBuilder;
+use byrokrat\id\Id;
+use byrokrat\banking\AccountNumber;
+use Hashids\Hashids;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class MandateKeyBuilderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(MandateKeyBuilder::CLASS);
+    }
+
+    function it_creates_keys_for_short_input(Id $id, AccountNumber $account)
+    {
+        $id->format('Ss')->willReturn('1');
+        $account->get16()->willReturn('11');
+
+        $this->buildKey($id, $account)->shouldBeString();
+    }
+
+    function it_creates_keys_for_long_input(Id $id, AccountNumber $account)
+    {
+        $id->format('Ss')->willReturn('999999999');
+        $account->get16()->willReturn('9999999999999999');
+
+        $this->buildKey($id, $account)->shouldBeString();
+    }
+
+    function it_fails_if_key_is_not_of_desired_length(Hashids $hashEngine, Id $id, AccountNumber $account)
+    {
+        $hashEngine->encode('11')->willReturn('this-is-not-16-chars');
+        $this->setHashEngine($hashEngine);
+
+        $id->format('Ss')->willReturn('1');
+        $account->get16()->willReturn('11');
+
+        $this->shouldThrow(\LogicException::CLASS)->duringBuildKey($id, $account);
+    }
+}

--- a/src/Builder/MandateKeyBuilder.php
+++ b/src/Builder/MandateKeyBuilder.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * This file is part of byrokrat\giroapp.
+ *
+ * byrokrat\giroapp is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * byrokrat\giroapp is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with byrokrat\giroapp. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright 2016-17 Hannes Forsgård
+ */
+
+declare(strict_types = 1);
+
+namespace byrokrat\giroapp\Builder;
+
+use byrokrat\id\Id;
+use byrokrat\banking\AccountNumber;
+use Hashids\Hashids;
+
+/**
+ * Create unique mandate keys
+ */
+class MandateKeyBuilder
+{
+    /**
+     * Number of chars in created keys
+     */
+    const KEY_LENGTH = 16;
+
+    /**
+     * @var Hashids
+     */
+    private $hashEngine;
+
+    /**
+     * Create a unique key based on input
+     */
+    public function buildKey(Id $id, AccountNumber $account): string
+    {
+        $key = $this->getHashEngine()->encode($id->format('Ss').substr($account->get16(), 0, -1));
+
+        if (strlen($key) != self::KEY_LENGTH) {
+            throw new \LogicException('Mandate key of wrong key size, this is an internal error.');
+        }
+
+        return $key;
+    }
+
+    /**
+     * Set internal hash engine (must create keys of the desired length!)
+     */
+    public function setHashEngine(Hashids $hashEngine)
+    {
+        $this->hashEngine = $hashEngine;
+    }
+
+    /**
+     * Get internal hash engine
+     */
+    private function getHashEngine(): Hashids
+    {
+        if (!isset($this->hashEngine)) {
+            $this->hashEngine = new Hashids(
+                '',
+                self::KEY_LENGTH,
+                'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890'
+            );
+        }
+
+        return $this->hashEngine;
+    }
+}


### PR DESCRIPTION
As promised. Here is my logic for creating mandate ids. If to be used this needs to be integrated into the Donor creation flow. I'm thinking something like a `DonorBuilder`.