### PR TITLE
Fix DonorMapper::findByActivePayerNumber

### DIFF
--- a/spec/Mapper/DonorMapperSpec.php
+++ b/spec/Mapper/DonorMapperSpec.php
@@ -73,7 +73,7 @@ class DonorMapperSpec extends ObjectBehavior
         $donorSchema->getPayerNumberSearchExpression('payer-number')->willReturn($expr);
         $collection->findOne($expr)->willReturn([]);
 
-        $this->shouldThrow(new \RuntimeException("unknown payer number: payer-number"))->duringFindByActivePayerNumber('payer-number');
+        $this->shouldThrow(\RuntimeException::CLASS)->duringFindByActivePayerNumber('payer-number');
     }
 
     function it_can_find_by_payer_number(

--- a/spec/Mapper/DonorMapperSpec.php
+++ b/spec/Mapper/DonorMapperSpec.php
@@ -68,6 +68,14 @@ class DonorMapperSpec extends ObjectBehavior
         $this->findByActivePayerNumber('payer-number')->shouldEqual($donor);
     }
 
+    function it_throws_on_erroneous_active_payernumber($collection, $donorSchema, ExpressionInterface $expr)
+    {
+        $donorSchema->getPayerNumberSearchExpression('payer-number')->willReturn($expr);
+        $collection->findOne($expr)->willReturn([]);
+
+        $this->shouldThrow(new \RuntimeException("unknown payer number: payer-number"))->duringFindByActivePayerNumber('payer-number');
+    }
+
     function it_can_find_by_payer_number(
         $collection,
         $donorSchema,

--- a/src/Mapper/DonorMapper.php
+++ b/src/Mapper/DonorMapper.php
@@ -99,11 +99,14 @@ class DonorMapper
      */
     public function findByActivePayerNumber(string $payerNumber): Donor
     {
-        return $this->donorSchema->fromArray(
-            $this->collection->findOne(
-                $this->donorSchema->getPayerNumberSearchExpression($payerNumber)
-            )
+        $post = $this->collection->findOne(
+            $this->donorSchema->getPayerNumberSearchExpression($payerNumber)
         );
+
+        if (!empty($post)) {
+            return $this->donorSchema->fromArray($post);
+        }
+        throw new \RunTimeException("unknown payer number: $payerNumber");
     }
 
     /**


### PR DESCRIPTION
Fix for an issue found in pr #59:
Updated DonorMapper::findByActivePayerNumber() to throw an error on erroneous payer number