### PR TITLE
Fix reading mandate request responses, close #82

### DIFF
--- a/features-missing/import.feature
+++ b/features-missing/import.feature
@@ -23,20 +23,6 @@ Feature: Importing files
         """
     Then I get an error
 
-  Scenario: I import an autogiro file rejecting a mandate register request
-    Given there are donors:
-      | payer-number | state            |
-      | 12345        | MandateSentState |
-    When I import:
-        """
-        01AUTOGIRO              20170817            AG-MEDAVI           1234560058056201
-        73005805620100000000000123455000000001111116198203232775     042320170817
-        092017081799000000000
-        """
-    Then the donor database contains:
-      | payer-number | state         |
-      | 12345        | InactiveState |
-
   Scenario: I import an autogiro file with a new digital mandate
     When I import:
         """

--- a/features/import.feature
+++ b/features/import.feature
@@ -28,6 +28,20 @@ Feature: Importing files
       | payer-number | state                |
       | 12345        | MandateApprovedState |
 
+  Scenario: I import an autogiro file rejecting a mandate register request
+    Given there are donors:
+      | payer-number | state            |
+      | 12345        | MandateSentState |
+    When I import:
+        """
+        01AUTOGIRO              20170817            AG-MEDAVI           1234560058056201
+        73005805620100000000000123455000000001111116198203232775     042320170817
+        092017081799000000000
+        """
+    Then the donor database contains:
+      | payer-number | state         |
+      | 12345        | ErrorState |
+
   Scenario: I import an autogiro file revocing a mandate
     Given there are donors:
       | payer-number | state       |

--- a/spec/Listener/MandateResponseListenerSpec.php
+++ b/spec/Listener/MandateResponseListenerSpec.php
@@ -30,8 +30,7 @@ class MandateResponseListenerSpec extends ObjectBehavior
         Node $payerNumberNode,
         Node $idNode,
         Node $accountNode,
-        Node $infoNode,
-        Node $commentNode,
+        Node $statusNode,
         Donor $donor,
         DonorMapper $donorMapper
     ) {
@@ -46,13 +45,10 @@ class MandateResponseListenerSpec extends ObjectBehavior
         $parentNode->getChild('account')->willReturn($accountNode);
         $accountNode->hasAttribute('account')->willReturn(false);
 
-        $parentNode->getChild('info')->willReturn($infoNode);
-        $infoNode->getValue()->willReturn('');
-        $infoNode->getAttribute('message_id')->willReturn('');
-        $infoNode->getAttribute('message')->willReturn('');
-
-        $parentNode->getChild('comment')->willReturn($commentNode);
-        $commentNode->getAttribute('message')->willReturn('');
+        $parentNode->getChild('status')->willReturn($statusNode);
+        $statusNode->getValue()->willReturn('');
+        $statusNode->getAttribute('message_id')->willReturn('');
+        $statusNode->getAttribute('message')->willReturn('');
 
         $donorMapper->findByActivePayerNumber('payer-number')->willReturn($donor);
 
@@ -115,10 +111,10 @@ class MandateResponseListenerSpec extends ObjectBehavior
 
     function it_fails_on_unknown_response_code(
         $event,
-        $infoNode,
+        $statusNode,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn('this-is-not-a-valid-autogiro-reposnose-code');
+        $statusNode->getAttribute('message_id')->willReturn('this-is-not-a-valid-autogiro-reposnose-code');
 
         $dispatcher->dispatch(Events::WARNING_EVENT, Argument::type(LogEvent::CLASS))->shouldBeCalled();
         $event->stopPropagation()->shouldBeCalled();
@@ -126,62 +122,14 @@ class MandateResponseListenerSpec extends ObjectBehavior
         $this->onMandateResponseEvent($event, '', $dispatcher);
     }
 
-    function it_sets_error_state_on_updated_payer_number(
-        $event,
-        $infoNode,
-        $donor,
-        $donorMapper,
-        EventDispatcherInterface $dispatcher
-    ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_UPDATED_PAYER_NUMBER_BY_RECIPIENT);
-
-        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
-        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
-        $donorMapper->save($donor)->shouldBeCalled();
-
-        $this->onMandateResponseEvent($event, '', $dispatcher);
-    }
-
-    function it_sets_error_state_on_specific_mandate_response_from_bank(
-        $event,
-        $infoNode,
-        $donor,
-        $donorMapper,
-        EventDispatcherInterface $dispatcher
-    ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_ACCOUNT_RESPONSE_FROM_BANK);
-
-        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
-        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
-        $donorMapper->save($donor)->shouldBeCalled();
-
-        $this->onMandateResponseEvent($event, '', $dispatcher);
-    }
-
-    function it_sets_error_state_on_mandate_deleted_due_to_unanswered_request(
-        $event,
-        $infoNode,
-        $donor,
-        $donorMapper,
-        EventDispatcherInterface $dispatcher
-    ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_DELETED_DUE_TO_UNANSWERED_ACCOUNT_REQUEST);
-
-        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
-        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
-        $donorMapper->save($donor)->shouldBeCalled();
-
-        $this->onMandateResponseEvent($event, '', $dispatcher);
-    }
-
     function it_sets_inactive_state_on_mandate_deleted_by_payer(
         $event,
-        $infoNode,
+        $statusNode,
         $donor,
         $donorMapper,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_DELETED_BY_PAYER);
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DELETED_BY_PAYER);
 
         $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
         $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
@@ -190,14 +138,64 @@ class MandateResponseListenerSpec extends ObjectBehavior
         $this->onMandateResponseEvent($event, '', $dispatcher);
     }
 
-    function it_sets_inactive_state_on_mandate_deleted_by_recipient(
+    function it_sets_error_state_on_account_not_allowed(
         $event,
-        $infoNode,
+        $statusNode,
         $donor,
         $donorMapper,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_DELETED_BY_RECIPIENT);
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_ACCOUNT_NOT_ALLOWED);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_mandate_does_not_exist(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DOES_NOT_EXIST);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_invalid_account_or_id(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INVALID_ACCOUNT_OR_ID);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_inactive_state_on_mandate_deleted_due_to_unanswered_request(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(
+            Messages::STATUS_MANDATE_DELETED_DUE_TO_UNANSWERED_ACCOUNT_REQUEST
+        );
 
         $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
         $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
@@ -206,14 +204,142 @@ class MandateResponseListenerSpec extends ObjectBehavior
         $this->onMandateResponseEvent($event, '', $dispatcher);
     }
 
-    function it_sets_inactive_state_on_mandate_deleted_due_to_closed_recipient_bg(
+    function it_sets_error_state_on_payer_number_does_not_exist(
         $event,
-        $infoNode,
+        $statusNode,
         $donor,
         $donorMapper,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_DELETED_DUE_TO_CLOSED_RECIPIENT_BG);
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_PAYER_NUMBER_DOES_NOT_EXIST);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_mandate_already_exists(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_ALREADY_EXISTS);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_invalid_id_or_bg_not_allowed(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INVALID_ID_OR_BG_NOT_ALLOWED);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_invalid_payer_number(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INVALID_PAYER_NUMBER);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_invalid_account(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INVALID_ACCOUNT);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_invalid_payee_account(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INVALID_PAYEE_ACCOUNT);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_inactive_payee_account(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_INACTIVE_PAYEE_ACCOUNT);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_approved_state_on_mandate_created(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_CREATED);
+
+        $donor->setState(Argument::type(MandateApprovedState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_APPROVED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_inactive_state_on_mandate_deleted(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DELETED);
 
         $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
         $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
@@ -224,12 +350,12 @@ class MandateResponseListenerSpec extends ObjectBehavior
 
     function it_sets_inactive_state_on_mandate_deleted_due_to_closed_payer_bg(
         $event,
-        $infoNode,
+        $statusNode,
         $donor,
         $donorMapper,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_DELETED_DUE_TO_CLOSED_PAYER_BG);
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DELETED_DUE_TO_CLOSED_PAYER_BG);
 
         $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
         $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
@@ -238,17 +364,81 @@ class MandateResponseListenerSpec extends ObjectBehavior
         $this->onMandateResponseEvent($event, '', $dispatcher);
     }
 
-    function it_sets_approved_state_on_mandate_created(
+    function it_sets_inactive_state_on_mandate_deleted_by_bank(
         $event,
-        $infoNode,
+        $statusNode,
         $donor,
         $donorMapper,
         EventDispatcherInterface $dispatcher
     ) {
-        $infoNode->getAttribute('message_id')->willReturn(Messages::MANDATE_CREATED_BY_RECIPIENT);
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DELETED_BY_BANK);
 
-        $donor->setState(Argument::type(MandateApprovedState::CLASS))->shouldBeCalled();
-        $dispatcher->dispatch(Events::MANDATE_APPROVED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_inactive_state_on_mandate_deleted_by_bgc(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_DELETED_BY_BGC);
+
+        $donor->setState(Argument::type(InactiveState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_mandate_blocked_by_payer(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_BLOCKED_BY_PAYER);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_mandate_block_removed(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_BLOCK_REMOVED);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
+        $donorMapper->save($donor)->shouldBeCalled();
+
+        $this->onMandateResponseEvent($event, '', $dispatcher);
+    }
+
+    function it_sets_error_state_on_mandate_max_amount_not_allowed(
+        $event,
+        $statusNode,
+        $donor,
+        $donorMapper,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $statusNode->getAttribute('message_id')->willReturn(Messages::STATUS_MANDATE_MAX_AMOUNT_NOT_ALLOWED);
+
+        $donor->setState(Argument::type(ErrorState::CLASS))->shouldBeCalled();
+        $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, Argument::type(DonorEvent::CLASS))->shouldBeCalled();
         $donorMapper->save($donor)->shouldBeCalled();
 
         $this->onMandateResponseEvent($event, '', $dispatcher);

--- a/src/Listener/MandateResponseListener.php
+++ b/src/Listener/MandateResponseListener.php
@@ -106,31 +106,42 @@ class MandateResponseListener
 
         $donorEvent = new DonorEvent(
             sprintf(
-                '%s: %s (%s)',
+                '%s: %s',
                 $donor->getMandateKey(),
-                $node->getChild('info')->getAttribute('message'),
-                $node->getChild('comment')->getAttribute('message')
+                $node->getChild('status')->getAttribute('message')
             ),
             $donor
         );
 
-        switch ($node->getChild('info')->getAttribute('message_id')) {
-            case Messages::MANDATE_DELETED_BY_PAYER:
-            case Messages::MANDATE_DELETED_BY_RECIPIENT:
-            case Messages::MANDATE_DELETED_DUE_TO_CLOSED_RECIPIENT_BG:
-            case Messages::MANDATE_DELETED_DUE_TO_CLOSED_PAYER_BG:
+        switch ($node->getChild('status')->getAttribute('message_id')) {
+            case Messages::STATUS_MANDATE_DELETED_BY_PAYER:
+            case Messages::STATUS_MANDATE_DELETED_DUE_TO_UNANSWERED_ACCOUNT_REQUEST:
+            case Messages::STATUS_MANDATE_DELETED:
+            case Messages::STATUS_MANDATE_DELETED_DUE_TO_CLOSED_PAYER_BG:
+            case Messages::STATUS_MANDATE_DELETED_BY_BANK:
+            case Messages::STATUS_MANDATE_DELETED_BY_BGC:
                 $donor->setState(new InactiveState);
                 $dispatcher->dispatch(Events::MANDATE_REVOKED_EVENT, $donorEvent);
                 break;
 
-            case Messages::MANDATE_CREATED_BY_RECIPIENT:
+            case Messages::STATUS_MANDATE_CREATED:
                 $donor->setState(new MandateApprovedState);
                 $dispatcher->dispatch(Events::MANDATE_APPROVED_EVENT, $donorEvent);
                 break;
 
-            case Messages::MANDATE_UPDATED_PAYER_NUMBER_BY_RECIPIENT:
-            case Messages::MANDATE_ACCOUNT_RESPONSE_FROM_BANK:
-            case Messages::MANDATE_DELETED_DUE_TO_UNANSWERED_ACCOUNT_REQUEST:
+            case Messages::STATUS_MANDATE_ACCOUNT_NOT_ALLOWED:
+            case Messages::STATUS_MANDATE_DOES_NOT_EXIST:
+            case Messages::STATUS_MANDATE_INVALID_ACCOUNT_OR_ID:
+            case Messages::STATUS_MANDATE_PAYER_NUMBER_DOES_NOT_EXIST:
+            case Messages::STATUS_MANDATE_ALREADY_EXISTS:
+            case Messages::STATUS_MANDATE_INVALID_ID_OR_BG_NOT_ALLOWED:
+            case Messages::STATUS_MANDATE_INVALID_PAYER_NUMBER:
+            case Messages::STATUS_MANDATE_INVALID_ACCOUNT:
+            case Messages::STATUS_MANDATE_INVALID_PAYEE_ACCOUNT:
+            case Messages::STATUS_MANDATE_INACTIVE_PAYEE_ACCOUNT:
+            case Messages::STATUS_MANDATE_BLOCKED_BY_PAYER:
+            case Messages::STATUS_MANDATE_BLOCK_REMOVED:
+            case Messages::STATUS_MANDATE_MAX_AMOUNT_NOT_ALLOWED:
                 $donor->setState(new ErrorState);
                 $dispatcher->dispatch(Events::MANDATE_INVALID_EVENT, $donorEvent);
                 break;
@@ -140,9 +151,9 @@ class MandateResponseListener
                     Events::WARNING_EVENT,
                     new LogEvent(
                         sprintf(
-                            '%s: invalid mandate response code: %s',
+                            '%s: invalid mandate status code: %s',
                             $donor->getMandateKey(),
-                            $node->getChild('info')->getValue()
+                            $node->getChild('status')->getValue()
                         )
                     )
                 );


### PR DESCRIPTION
This fix utilizes some renaming in `byrokrat/autogiro`. So you need to run **composer update** after merging for tests to pass...